### PR TITLE
Allow repo path

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -14,7 +14,7 @@ fn git_repository_open_from_workdir(path: PathBuf) -> Repository {
 
 // Create a git branch in the current repository
 pub fn branch_create(repo_path: Option<PathBuf>, branch_name: std::string::String) {
-    let path = repo_path.unwrap_or(PathBuf::from("."));
+    let path = repo_path.unwrap_or_else(|| PathBuf::from("."));
     let repo = git_repository_open_from_workdir(path);
     let head = repo.head().unwrap();
     let head_commit = head.peel_to_commit().unwrap();

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,16 +3,17 @@
 
 use git2::Repository;
 
-fn git_repository_open_from_workdir() -> Repository {
-    match Repository::open(".") {
+fn git_repository_open_from_workdir(path: &str) -> Repository {
+    match Repository::open(path) {
         Ok(repo) => repo,
         Err(e) => panic!("failed to open: {}", e),
     }
 }
 
 // Create a git branch in the current repository
-pub fn branch_create(branch_name: std::string::String) {
-    let repo = git_repository_open_from_workdir();
+pub fn branch_create(repo_path: Option<&str>, branch_name: std::string::String) {
+    let path = repo_path.unwrap_or(".");
+    let repo = git_repository_open_from_workdir(path);
     let head = repo.head().unwrap();
     let head_commit = head.peel_to_commit().unwrap();
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,12 +4,10 @@
 use git2::Repository;
 
 fn git_repository_open_from_workdir() -> Repository {
-    let repo = match Repository::open(".") {
+    match Repository::open(".") {
         Ok(repo) => repo,
         Err(e) => panic!("failed to open: {}", e),
-    };
-
-    return repo;
+    }
 }
 
 // Create a git branch in the current repository

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,9 +1,11 @@
 // This is a git adapter for the git2 crate. it is used to create a git branch
 // in the current repository
 
+use std::path::PathBuf;
+
 use git2::Repository;
 
-fn git_repository_open_from_workdir(path: &str) -> Repository {
+fn git_repository_open_from_workdir(path: PathBuf) -> Repository {
     match Repository::open(path) {
         Ok(repo) => repo,
         Err(e) => panic!("failed to open: {}", e),
@@ -11,8 +13,8 @@ fn git_repository_open_from_workdir(path: &str) -> Repository {
 }
 
 // Create a git branch in the current repository
-pub fn branch_create(repo_path: Option<&str>, branch_name: std::string::String) {
-    let path = repo_path.unwrap_or(".");
+pub fn branch_create(repo_path: Option<PathBuf>, branch_name: std::string::String) {
+    let path = repo_path.unwrap_or(PathBuf::from("."));
     let repo = git_repository_open_from_workdir(path);
     let head = repo.head().unwrap();
     let head_commit = head.peel_to_commit().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,10 @@ enum Commands {
     },
     /// Display a fuzzy_finder interface to select an issue from
     /// the board and create a git branch from it
-    New {},
+    New {
+        #[arg(required = false)]
+        path: Option<PathBuf>,
+    },
 }
 
 fn create_fuzzy_finder(issues: Vec<String>) -> String {
@@ -89,10 +92,10 @@ fn main() {
             println!("Init");
             println!("{:?}", config);
         }
-        Commands::New {} => {
+        Commands::New { path } => {
             let item = create_fuzzy_finder(issues);
             println!();
-            git::branch_create(None, item.clone());
+            git::branch_create(path, item.clone());
 
             println!("Created branch {}", item);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
         Commands::New {} => {
             let item = create_fuzzy_finder(issues);
             println!();
-            git::branch_create(item.clone());
+            git::branch_create(None, item.clone());
 
             println!("Created branch {}", item);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,23 +49,16 @@ fn create_fuzzy_finder(issues: Vec<String>) -> String {
     // Prompt the user to select an issue from the list of issues
     let items_count = items.len();
 
-    let find_result = match fuzzy_finder::FuzzyFinder::find(items, items_count.try_into().unwrap())
-    {
-        Ok(result) => result,
+    match fuzzy_finder::FuzzyFinder::find(items, items_count.try_into().unwrap()) {
+        Ok(Some(result)) => result,
+        Ok(None) => {
+            panic!("Invalid result");
+        }
         Err(e) => {
             std::io::stdout().flush().unwrap();
             panic!("Failed to find result: {}", e);
         }
-    };
-    let item = match find_result {
-        Some(result) => result,
-        None => {
-            panic!("Invalid result");
-        }
-    };
-    println!();
-
-    return item;
+    }
 }
 
 fn main() {
@@ -98,6 +91,7 @@ fn main() {
         }
         Commands::New {} => {
             let item = create_fuzzy_finder(issues);
+            println!();
             git::branch_create(item.clone());
 
             println!("Created branch {}", item);


### PR DESCRIPTION
Channge the interface so that `gcb new` allows to give a path to a repo instead of always using the current directory.

Makes it also easier to test for now ;) .